### PR TITLE
Configure CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,24 @@ env:
   matrix:
   - CONFIGURATION=Debug
   - CONFIGURATION=Release
-script:
+install:
 - nvm install 8
-- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-- cd spectre-upload
+- echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
+- pushd spectre-upload
 - npm install
-- cd ..
+- popd
 - dotnet restore spectre-upload.sln
+script:
 - dotnet build -c $CONFIGURATION spectre-upload.sln
 - |
-  if [ $CONFIGURATION = "Release" ]
-  then
+  if [ $CONFIGURATION = "Release" ]; then
       docker build -t spectre-upload --file spectre-upload/Dockerfile .
       docker images
-      if [ $TRAVIS_PULL_REQUEST = "false" ]
-      then
-          if [ $TRAVIS_BRANCH = "master" ]
-          then
+      if [ $TRAVIS_PULL_REQUEST = "false" ]; then
+          if [ $TRAVIS_BRANCH = "master" ]; then
               docker tag spectre-upload spectreteam/spectre-upload:latest
               docker push spectreteam/spectre-upload:latest
-          elif [ $TRAVIS_BRANCH = "develop" ]
-          then
+          elif [ $TRAVIS_BRANCH = "develop" ]; then
               docker tag spectre-upload spectreteam/spectre-upload:beta
               docker push spectreteam/spectre-upload:beta
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: csharp
+solution: spectre-upload.sln
+mono: none
+dotnet: 2.1.4
+sudo: required
+services:
+- docker
+env:
+  global:
+  - VERSION=1.0.0
+  - secure: iHs7pgKlNFp9tK1Fn50KriRQy02a3cfdRfLqxTjQwBrZGTZm6g6xVHPI6gpDZ8KciiyECRhyDx5dsBqB1xg9+GEOAPTHKCzWrWPNRqburhnbd65/iAxlZun+DYbJl1nwf7UsW6TmOiNAfLfl8aXmdpiLuF2x8/eOd1kfOgehgJe/eBrM/B4IOuYmtBJ7v33yHJpvzwMajonQh3upKFoPrFtdkBY86ElMZ1d7kMz8B1q1L6ATNZ4PszGETZoe4PC+Dtijto73LMxSWZDFN4zZz3FyXddpwgTDITa5Q//kucxHBiiWNFp13Rab0j2jYK4XrqquqAvPqcA7pRUvGrdnfDMnGa1d3gZ04DFIe58a7E2buqpYh3LJVAWfYRUI+tY1Mv+9/VbwRERPgKU/DCX7xHRkdLT23sp+w4YOI6vrxcLoH0hQzzLHbqqtqrq/TWOgOnv/7kqdjhox4of/qurG5F0Fuw7cCosb6a8/FuN7/ZO164dv1gZuyjqIgxBLcJURlb0Q3LU5DO8iDLFow6u0rkcy4p/qyesxj6T5Ihg/WygWgpfqAcu1qHNQtZrudAUOHSUtTlxixhLJyyGQ3Li7AvzpoAZHJ9TLcbimlny0Bh9JAKrWa5+a5NLGBxfjpljIZM6h0vtHaIaFWUujspHH2mcn27KYZizXaVPBlUkszNs=
+  - secure: g+LbQhGM6/di3eenMsd1X+iKXIynjPP/y6HWtbQSy23AjFkqGNQJ+QH+Pvk93lcEEcgFzD6v+rcAc/WabgroMca8cAHe8/RUYVg3RCLyxOjNf4aSTX2Lc+B+TZ7terQpzolD0W2eIJevZMIgX+WvpZW1Luqcy52AFjF39GhUmTD90RWjx2l7As9eRZqSLFcFF7F8Z6N7qSSfnSN7z0rp/EWjlHrvVk2yMHVqxvK8YUS7LxoPZlicN1JUSbV9q5CexAQ7t8ulXYPwE7T7ejcU9WMuPJSfcEijA4xOlDu2dotNmOYjxnm4tD0MDPom8df/816gleaC8moekCQMeZaNVqqDWiX/4H6qHUePCsUeXzgl7sWQWfIhBIR6hopwB3R9zWUWp3vqKarGHfe6H5yn/W5VHb0S3ElRPW/lEoPNKZC9Ie6Ppf0oQysbg5VsidF+FYVNCoDvgYO5Tjxr2DwdRfjxCy38vAYHcZWVJE8TrQKik++aFFaIqZcuUbrB9ydgIY1+Q2ksnVKdbwHlej8yEBsifPkzaXfIoBpA475Mv/lt2Vce3p2LoQI8G/dQ0YzltrO8tlyaPK6D/28a24JQrvAPljeKngoU0OW3hHJJZDZ8mJfD4qZHq9xwQUwWkJgjzFKy3QbFgxTND564F27IV4DEVMYRCpnx/olOPBu5fCg=
+  matrix:
+  - CONFIGURATION=Debug
+  - CONFIGURATION=Release
+script:
+- nvm install 8
+- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+- cd spectre-upload
+- npm install
+- cd ..
+- dotnet restore spectre-upload.sln
+- dotnet build -c $CONFIGURATION spectre-upload.sln
+- |
+  if [ $CONFIGURATION = "Release" ]
+  then
+      docker build -t spectre-upload --file spectre-upload/Dockerfile .
+      docker images
+      if [ $TRAVIS_PULL_REQUEST = "false" ]
+      then
+          if [ $TRAVIS_BRANCH = "master" ]
+          then
+              docker tag spectre-upload spectreteam/spectre-upload:latest
+              docker push spectreteam/spectre-upload:latest
+          elif [ $TRAVIS_BRANCH = "develop" ]
+          then
+              docker tag spectre-upload spectreteam/spectre-upload:beta
+              docker push spectreteam/spectre-upload:beta
+          fi
+          docker tag spectre-upload spectreteam/spectre-upload:$VERSION.$TRAVIS_BUILD_NUMBER
+          docker push spectreteam/spectre-upload:$VERSION.$TRAVIS_BUILD_NUMBER
+      fi
+  fi
+notifications:
+  webhooks:
+    urls:
+      secure: fhzbp0AqVGuu4MuGTj40jrUXshohcYt+h9U0ns359AIQkqhgFZJ7nfZNYezE1FV00tighoIuTUzbRUaBmgUYDe0wNNzGE38frRrpJc6iMw0s4Pbm0h3nENAILwGgOi043cI2EjVSVHfOF8//+Ys+PapMn+Gn1l1Y5bZ/uAVHHBnqLCtDbvCnU4tJT4ZLymSnMWfwoWdEz0Uj0I9UJykryreH9Fui3nwMGucijMDJyxYZ4u9B5TseKyWbGB3EtQGUcM/VfOn17ynK3FMIpjaHcqJWOHicMtHPp4UAD1xq31809e4tvkllnrGsCTvcoHKWY4PtQzxavG/xiJ25ptVlwrzCADjQNhg63THSAHHvnksmmKCNV4iCUzO+fHrlTq9MccgsdblTMEiKTqfgajafAxfa3UyJNhGcHm4+8/moawMTp7EjTj2sshEiw3GMktACOInj7YNeJGeSQh2WFCMDMfdv+wrxS+OH6BbxOyQOtXccxL5j73Mxz055AUei5JijNnvcrm2l+gH5KHs3zeHP0G4BTClZ9qsOBMbx/DGKk6Y4eueHzUk7KkvzG/5RLkK0xAOcgSmI+DA/bozWJirOCdKLlj6GyHA/+qVY6jcC3373uSvbVnSihdQYir/hN9nJ7hM0ReWWtxXi++CDakEvOO0Epn3awN6I5hoHsb/0FTg=
+  on_success: always
+  on_failure: always
+  on_start: never
+  on_cancel: never
+  on_error: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/spectre-team/spectre-upload/badge)](https://www.codefactor.io/repository/github/spectre-team/spectre-upload)
 [![BCH compliance](https://bettercodehub.com/edge/badge/spectre-team/spectre-upload?branch=master)](https://bettercodehub.com/)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/ic5kxf1eke0hclt2/branch/master?svg=true)](https://ci.appveyor.com/project/gmrukwa/spectre-upload/branch/master)
+[![Linux build status](https://travis-ci.org/spectre-team/spectre-upload.svg?branch=master)](https://travis-ci.org/spectre-team/spectre-upload)
 
 ![Spectre](https://user-images.githubusercontent.com/1897842/31115297-0fe2c3aa-a822-11e7-90e6-92ceccf76137.jpg)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+version: 1.0.0.{build}
+skip_tags: true
+skip_branch_with_pr: true
+max_jobs: 8
+image: Visual Studio 2017
+configuration:
+- Debug
+- Release
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+services: iis
+install:
+- ps: >-
+    dotnet restore spectre-upload.sln
+
+    Install-Product node 8 x64
+
+    cd spectre-upload
+
+    npm install
+
+    cd ..
+build:
+  project: spectre-upload.sln
+  parallel: true
+  verbosity: minimal
+test: off
+deploy: off
+notifications:
+# this publishes to Continuous Integration channel in Glip
+- provider: Webhook
+  url:
+    secure: V16hjhyXfcLNyhNUih9v1Lb4wDly5r6CNNufciMrvllwt0m0rkguf6o4DY7pbdKia/vJGmErvQLdEW0MkzqsAhLWiPY7+Z6qvzFjweP8xNg=
+  method: POST
+  content_type: application/json
+  body: >-
+    {
+      "icon": "https://www.appveyor.com/assets/img/appveyor-logo-256.png",
+      "activity": "AppVeyor for spectre-upload",
+      "title": "Build {{buildVersion}} **{{#failed}}failed{{/failed}}{{#passed}}passed{{/passed}}** in {{duration}}",
+      "body": "{{#isPullRequest}}Pull request: [#{{pullRequestId}}](https://github.com/spectre-team/spectre-upload/pull/{{pullRequestId}})\n{{/isPullRequest}}Branch: [{{branch}}](https://github.com/spectre-team/spectre-upload/tree/{{branch}})\nCommit: [{{commitId}} {{commitMessage}}](https://github.com/spectre-team/spectre-upload/commit/{{commitId}})\nAuthor: {{commitAuthor}}\n[Build details]({{buildUrl}})"
+    }
+  on_build_success: true
+  on_build_failure: true
+  on_build_status_changed: true


### PR DESCRIPTION
I've configured CI on AppVeyor & Travis. Right now we have Travis CI publishing Docker image to the hub, while `docker-compose` project in Visual Studio has been disabled, due to following reasons:

- for Linux, there was `Microsoft.Docker.Sdk` missing, so it could not build on Travis as all
- for Windows, there is Docker Enterprise installed on AppVeyor, which supports only Windows targets, and therefore also could not build at all

For your convenience, in manual testing of the service, you just right-click the `docker-compose` project in Visual Studio, make it build, and then run.

Right now on `develop` we have just a sample project, from Visual Studio template - it will be updated in the next turn, but I've wanted to configure CI properly at the beginning.

Test running will be added when tests will appear, as I have to dig into some details of multiplatform testing for .NET Core.